### PR TITLE
Add else to if statements for fluidic compressor canister stacking

### DIFF
--- a/src/main/java/buildcraftAdditions/entities/TileFluidicCompressor.java
+++ b/src/main/java/buildcraftAdditions/entities/TileFluidicCompressor.java
@@ -79,7 +79,7 @@ public class TileFluidicCompressor extends TileBuildCraft implements ISidedInven
                                     inventory.setInventorySlotContents(1, itemstack);
                                     inventory.setInventorySlotContents(0, null);
                                 }
-                                if (inventory.getStackInSlot(1).getItem() == inventory.getStackInSlot(0).getItem() && inventory.getStackInSlot(1).stackSize < 4){
+                                else if (inventory.getStackInSlot(1).getItem() == inventory.getStackInSlot(0).getItem() && inventory.getStackInSlot(1).stackSize < 4){
                                     inventory.getStackInSlot(1).stackSize++;
                                     inventory.setInventorySlotContents(0, null);
                                 }
@@ -104,7 +104,7 @@ public class TileFluidicCompressor extends TileBuildCraft implements ISidedInven
                                 inventory.setInventorySlotContents(1, itemstack);
                                 inventory.setInventorySlotContents(0, null);
                             }
-                            if (inventory.getStackInSlot(1).getItem() == inventory.getStackInSlot(0).getItem() && inventory.getStackInSlot(1).stackSize < 4){
+                            else if (inventory.getStackInSlot(1).getItem() == inventory.getStackInSlot(0).getItem() && inventory.getStackInSlot(1).stackSize < 4){
                                 inventory.getStackInSlot(1).stackSize++;
                                 inventory.setInventorySlotContents(0, null);
                             }


### PR DESCRIPTION
Hi, I'm new to modding here, but with some little programming experience.
Just thought I would note this issue with the fluidic compressor crashing when finishing filling or emptying a canister.
I added else's to the second if statements to prevent trying to reference the input canister stack when it is set as NULL by the previous if statement. This seems to fix it.
