### PR TITLE
fix the texture of the coloring tool and color textures in the itemSorter

### DIFF
--- a/src/main/java/buildcraftAdditions/items/Tools/ItemPipeColoringTool.java
+++ b/src/main/java/buildcraftAdditions/items/Tools/ItemPipeColoringTool.java
@@ -113,7 +113,7 @@ public class ItemPipeColoringTool extends ItemPoweredBase {
 	public void registerIcons(IIconRegister register) {
 		icons = new IIcon[names.length];
 		for (int i = 0; i < names.length; i++)
-			icons[i] = register.registerIcon("buildcraft:triggers/color_" + names[i]);
+			icons[i] = register.registerIcon("buildcraftcore:paintbrush/" + names[i]);
 	}
 
 	@Override


### PR DESCRIPTION
This was needed because of the texture location change from BC 7. This just fixes our textures but now that BC has it's own brushes it might be annoying to use the current textures...